### PR TITLE
chore: add openssl as module

### DIFF
--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -55,7 +55,7 @@ modules:
   - name: openssl
     buildsystem: simple
     build-commands:
-      - ./config --prefix=/app --openssldir=/app/ssl -Dshared=true
+      - ./config --prefix=/app --openssldir=/app/etc/ssl -Dshared=true zlib no-tests
       - make
       - make install
     sources:

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -53,9 +53,11 @@ modules:
         url: https://download.gnome.org/sources/gcr/3.34/gcr-3.34.0.tar.xz
 
   - name: openssl
-    buildsystem: meson
-    config-opts:
-      - -Dshared=true
+    buildsystem: simple
+    build-commands:
+      - ./config --prefix=/app --openssldir=/app/ssl -Dshared=true
+      - make
+      - make install
     sources:
       - type: archive
         url: https://www.openssl.org/source/openssl-3.2.0.tar.gz

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -54,8 +54,10 @@ modules:
 
   - name: openssl
     buildsystem: simple
-    config-opts:
-      - --prefix=/app
+    build-commands:
+      - ./config --prefix=/app --openssldir=/app --libdir=lib shared zlib no-tests
+      - make
+      - make install
     sources:
       - type: archive
         url: https://github.com/openssl/openssl/releases/download/openssl-3.2.3/openssl-3.2.3.tar.gz

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -55,7 +55,7 @@ modules:
   - name: openssl
     buildsystem: simple
     build-commands:
-      - ./config --prefix=/app --openssldir=/app/etc/ssl -Dshared=true zlib no-tests
+      - ./config --prefix=/app --openssldir=/app --libdir=lib shared zlib no-tests
       - make
       - make install
     sources:

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -60,8 +60,13 @@ modules:
       - make install
     sources:
       - type: archive
-        url: https://www.openssl.org/source/openssl-3.2.0.tar.gz
-        sha256: "14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e"
+        url: https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz
+        sha256: 2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/openssl/openssl/releases/latest
+          version-query: .tag_name | sub("^openssl-"; "")
+          url-query: .assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url
 
   - name: zed
     buildsystem: simple

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -54,19 +54,12 @@ modules:
 
   - name: openssl
     buildsystem: simple
-    build-commands:
-      - ./config --prefix=/app --openssldir=/app --libdir=lib shared zlib no-tests
-      - make
-      - make install
+    config-opts:
+      - --prefix=/app
     sources:
       - type: archive
-        url: https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz
-        sha256: 2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/openssl/openssl/releases/latest
-          version-query: .tag_name | sub("^openssl-"; "")
-          url-query: .assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url
+        url: https://github.com/openssl/openssl/releases/download/openssl-3.2.3/openssl-3.2.3.tar.gz
+        sha256: 52b5f1c6b8022bc5868c308c54fb77705e702d6c6f4594f99a0df216acf46239
 
   - name: zed
     buildsystem: simple

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -52,6 +52,15 @@ modules:
         sha256: 29df50974a90987af694c0fb8926a6b366e68cacd8abd813817cfe1eb5d54524
         url: https://download.gnome.org/sources/gcr/3.34/gcr-3.34.0.tar.xz
 
+  - name: openssl
+    buildsystem: meson
+    config-opts:
+      - -Dshared=true
+    sources:
+      - type: archive
+        url: https://www.openssl.org/source/openssl-3.2.0.tar.gz
+        sha256: "14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e"
+
   - name: zed
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
open terminal
`flatpak: /var/lib/flatpak/app/dev.zed.Zed/x86_64/stable/43109795a0a1489151b14d6bc71ebb7b3117a420fd59353f339ac8a28f1fdc75/files/lib/libssl.so.3: version 'OPENSSL_3.2.0' not found (required by /lib64/libcurl.so.4)`