### PR TITLE
fix: add missing file argument

### DIFF
--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -79,7 +79,7 @@ modules:
         fi
 
       # Ensure zed-wrapper is used as the Exec command in the `.desktop` file
-      - desktop-file-edit --set-key="Exec" --set-value="zed-wrapper" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - desktop-file-edit --set-key="Exec" --set-value="zed-wrapper %U" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
       # Modify original `.desktop` file to use the correct icon name
       - desktop-file-edit --set-icon="${FLATPAK_ID}" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
     sources:


### PR DESCRIPTION
_Follow up of https://github.com/zed-industries/zed/pull/23321_

## Without this fix

`xdg-open zed://file/home/user/project` will not open `/home/user/project` but will restore that last active Zed project (if closed, empty project otherwise)

## With this fix

`xdg-open zed://file/home/user/project` will open `/home/user/project`

_tested on Fedora 41 with Flatpak 1.15.91_