### PR TITLE
Add host-spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,65 @@ To cope with it, Zed's flatpak defaults can be changed to:
 When Zed's flatpak is running in the sandbox with no escape, it is not possible to execute commands on the host system.
 
 To execute commands on the host system, run inside the sandbox:
+
 ```shell
-  $ flatpak-spawn --host <COMMAND>
+$ flatpak-spawn --host <COMMAND>
+```
+
+or
+
+```shell
+$ host-spawn <COMMAND>
+```
+
+- Most users seem to report a better experience with `host-spawn`
+
+### Use host shell in the integrated terminal.
+
+Another option to execute commands is to use your host shell in the integrated terminal instead of the sandbox one.
+
+For that, open Zed's settings via <kbd>Ctrl</kbd> + <kbd>,</kbd>
+
+The following examples will figure out and launch the current user's preferred terminal. More configuration settings for spawning commands can be found in [Zed's documentation](https://zed.dev/docs/configuring-zed#terminal-shell).
+
+`flatpak-spawn --host`
+
+```json
+{
+  "terminal": {
+    "shell": {
+      "with_arguments": {
+        "program": "/usr/bin/flatpak-spawn",
+        "args": [
+          "--host",
+          "--env=TERM=xterm-256color",
+          "sh",
+          "-c",
+          "exec $(getent passwd $USER | cut -d: -f7)"
+        ]
+      }
+    }
+  },
+}
+```
+
+`host-spawn`
+
+```json
+{
+  "terminal": {
+    "shell": {
+      "with_arguments": {
+        "program": "/app/bin/host-spawn",
+        "args": [
+          "sh",
+          "-c",
+          "exec $(getent passwd $USER | cut -d: -f7)"
+        ]
+      }
+    }
+  },
+}
 ```
 
 ### SDK extensions

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -155,6 +155,36 @@ modules:
           is-main-source: true
       - type: file
         path: dev.zed.Zed.metainfo.xml
+  
+  - name: host-spawn
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 host-spawn /app/bin/host-spawn
+    sources:
+      - type: file
+        url: https://github.com/1player/host-spawn/releases/download/v1.6.1/host-spawn-x86_64
+        sha256: 733746ab498e07d065cbecf80bacd447eb21846d1462e8fe23fdd9d9dc977b50
+        dest-filename: host-spawn
+        only-arches: [x86_64]
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/1player/host-spawn/releases/latest
+          tag-query: .tag_name
+          version-query: .tag_name
+          timestamp-query: .published_at
+          url-query: '[.assets[] | select(.name|test(".+x86_64$"))][0] | .browser_download_url'
+      - type: file
+        url: https://github.com/1player/host-spawn/releases/download/v1.6.1/host-spawn-aarch64
+        sha256: 71b7744a4d0b29279523cc0f0ed1a7af5e9555510bd9e6d4685391b59faefaac
+        dest-filename: host-spawn
+        only-arches: [aarch64]
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/1player/host-spawn/releases/latest
+          tag-query: .tag_name
+          version-query: .tag_name
+          timestamp-query: .published_at
+          url-query: '[.assets[] | select(.name|test(".+aarch64$"))][0] | .browser_download_url'
 
   - name: zed-wrapper
     buildsystem: meson


### PR DESCRIPTION
`host-spawn` is better than `flatpak-spawn --host`.

- It allows secure commands like `sudo` and `doas` to work correctly. These won't work with `flatpak-spawn --host`
- It gets rid of these errors when you startup the terminal: `bash: cannot set terminal process group (-1): Not a tty` and `bash: no job control in this shell`
- It's already used and recommended by the VSCode, VSCodium, QMLKonsole, Yazi and other flatpaks

It will massively improve the experience for users who don't like Zed escaping the sandbox.
