### PR TITLE
Avoid overwriting SDK or installed libs by zed prebuilt ones

### DIFF
--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -108,7 +108,7 @@ modules:
       - install -Dm 644 ${FLATPAK_ID}.metainfo.xml --target-directory ${FLATPAK_DEST}/share/metainfo
       - install -Dm 644 share/icons/hicolor/512x512/apps/zed.png --target-directory ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps
       # Only install zed prebuilt libraries that do not already exist in destination
-      - for lib in lib/*; do [ -f "${FLATPAK_DEST}/$lib" ] || install -Dm755 "$lib" "${FLATPAK_DEST}/$lib"; done
+      - for lib in lib/*; do [ -f "${FLATPAK_DEST}/$lib" ] || install -Dm 755 $lib --target-directory ${FLATPAK_DEST}/lib; done
 
       # Rename instances of `zed` to `${FLATPAK_ID}`
       - rename zed ${FLATPAK_ID} ${FLATPAK_DEST}/share/{applications/*,icons/hicolor/*/apps/*}


### PR DESCRIPTION
zed linux releases come with some prebuilt libs that are also provided by freedesktop Sdk.
The only one not provided by the Sdk is libbsd but it's built and installed by the flatpak as a dependency to netcat

The error comes from libbsd.so.0, a symlink to libbsd.so.0.12.2 being overwritten by zed installation

Checking for lib existence before installing them to avoid overwriting already provided one fixes the problem

Fixes #175