### PR TITLE
fix: use statically linked netcat

### DIFF
--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -8,7 +8,9 @@ separate-locales: false
 cleanup:
   - /include
   - /lib/pkgconfig
+  - /share/info
   - /share/man
+  - /man
   - "/lib/*.a"
   - "/lib/*.la"
 finish-args:
@@ -36,11 +38,9 @@ modules:
     cleanup:
       - /lib/debug
       - /lib/girepository-1.0
-      - /man
       - /share/gir-1.0
       - /share/doc
       - /share/gtk-doc
-      - /share/info
       - /share/pkgconfig
     config-opts:
       - -Dgtk_doc=false


### PR DESCRIPTION
zed linux releases come with some prebuilt libs, notably libbsd which conflicts with the one we build as a dependency for netcat.

Statically linking netcat to libbsd and libmd avoids the conflict and resolves the error
This is a followup to https://github.com/flathub/dev.zed.Zed-Preview/pull/108 which caused issues, see https://github.com/flathub/dev.zed.Zed/issues/241

Fixes https://github.com/flathub/dev.zed.Zed/issues/175

Also fix netcat-openbsd anitya config