### PR TITLE
Add support for Devcontainers in sandbox mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,62 @@ Please open issues under: https://github.com/flathub/dev.zed.Zed/issues
 
 ## Usage
 
-Zed's current Flatpak integration exits the sandbox on startup and most functionalities work out of the box. Workflows that rely on Flatpak's sandboxing may not work as expected by default.
+Zed's current Flatpak integration runs Zed outside the Flatpak sandbox, on the host system. Users have encountered issues with language toolchains and other commands while in this mode, see e.g. https://github.com/flathub/dev.zed.Zed/issues/330 for discussion.
 
-Please note that Zed's flatpak still runs in an isolated environment and some language toolchains might misbehave when executed from the host OS into the sandbox.  
-To cope with it, Zed's flatpak defaults can be changed to: 
-  - disable sandbox escape at startup
-  - enable SDK extensions to get support for additional languages
+If you are experiencing these issues, one workaround is to run Zed inside the Flatpak sandbox with:
 
-### Environment variables
+```shell
+flatpak override --user dev.zed.Zed --env=ZED_FLATPAK_NO_ESCAPE=1
+```
 
-- `ZED_FLATPAK_NO_ESCAPE`: disable flatpak sandbox escape (default: not set)
-  ```shell
-    $ flatpak override --user dev.zed.Zed --env=ZED_FLATPAK_NO_ESCAPE=1
-  ```
+The Flatpak sandbox provides a basic development environment (Git, GCC, Python, etc.) by default. To use a more complex development environment, you can:
+  - use Dev Containers
+  - execute commands (including your shell) on the host system
+  - enable SDK extensions for additional languages
+
+### Dev Containers
+
+Dev Containers provide a consistent, reproducible environment using Docker/Podman containerization. This description exists as part of the repository in `.devcontainer/`.
+
+Zed has native support for Dev Containers. Use the `project: open dev container` command if you already have a `.devcontainer/`, otherwise you can generate one using the `project: initialize dev container` command.
+
+Note that you need to install the container runtime on your host system. If you are using Podman, you also need to set `"use_podman": true` in your Zed `settings.json`.
+
+#### Docker instructions
+
+1. [Install Docker](https://docs.docker.com/engine/install/) if you haven't already
+2. Add your user to the `docker` group (`sudo usermod -aG docker $(whoami)`)
+3. Confirm it works by running `docker run --rm docker.io/hello-world` from the Zed built-in terminal
+
+#### Podman instructions
+
+1. [Install Podman](https://podman.io/docs/installation) if you haven't already
+2. Enable/start the Podman socket with `systemctl --user enable --now podman.socket`
+3. Confirm it works by running `podman -r run --rm quay.io/podman/hello` from the Zed built-in terminal
+4. If your host Podman is older than 5.6.0, you also need to set:
+
+```shell
+flatpak override --user dev.zed.Zed --filesystem=/tmp/devcontainer-zed:create
+```
+
+5. Set `"use_podman": true` in your Zed `settings.json`
+
+See also the [Podman Rootless Tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration) for more detailed instructions and troubleshooting.
+
+#### Podman Desktop instructions
+
+1. [Install Podman Desktop](https://podman-desktop.io/docs/installation/linux-install) if you haven't already
+2. Leave Podman Desktop running in the background while using Zed
+3. Confirm it works by running `podman -r run --rm quay.io/podman/hello` from the Zed built-in terminal
+4. If your host Podman is older than 5.6.0, you also need to set:
+
+```shell
+flatpak override --user dev.zed.Zed --filesystem=/tmp/devcontainer-zed:create
+```
+
+5. Set `"use_podman": true` in your Zed `settings.json`
+
+See also the [Podman Rootless Tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration) for more detailed instructions and troubleshooting.
 
 ### Execute commands on the host system
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,76 @@ Please open issues under: https://github.com/flathub/dev.zed.Zed/issues
 
 ## Usage
 
-Zed's current Flatpak integration exits the sandbox on startup and most functionalities work out of the box. Workflows that rely on Flatpak's sandboxing may not work as expected by default.
+Zed's current Flatpak integration runs Zed outside the Flatpak sandbox, on the host system. Users have encountered issues with language toolchains and other commands while in this mode, see e.g. https://github.com/flathub/dev.zed.Zed/issues/330 for discussion.
 
-Please note that Zed's flatpak still runs in an isolated environment and some language toolchains might misbehave when executed from the host OS into the sandbox.  
-To cope with it, Zed's flatpak defaults can be changed to: 
-  - disable sandbox escape at startup
-  - enable SDK extensions to get support for additional languages
+If you are experiencing these issues, one workaround is to run Zed inside the Flatpak sandbox with:
 
-### Environment variables
+```shell
+flatpak override --user dev.zed.Zed --env=ZED_FLATPAK_NO_ESCAPE=1
+```
 
-- `ZED_FLATPAK_NO_ESCAPE`: disable flatpak sandbox escape (default: not set)
-  ```shell
-    $ flatpak override --user dev.zed.Zed --env=ZED_FLATPAK_NO_ESCAPE=1
-  ```
+The Flatpak sandbox provides a basic development environment (Git, GCC, Python, etc.) by default. To use a more complex development environment, you can:
+  - use Dev Containers
+  - execute commands (including your shell) on the host system
+  - enable SDK extensions for additional languages
+
+### Dev Containers
+
+Dev Containers provide a consistent, reproducible environment using Docker/Podman containerization. This description exists as part of the repository in `.devcontainer/`.
+
+Zed has native support for Dev Containers. Use the `project: open dev container` command if you already have a `.devcontainer/`, otherwise you can generate one using the `project: initialize dev container` command.
+
+Note that you need to install the container runtime on your host system. If you are using Podman, you also need to set `"use_podman": true` in your Zed `settings.json`.
+
+> [!IMPORTANT]
+> Docker Compose is not provided by the Flatpak. If you need this support, consider installing the necessary `docker-compose` plugin to `~/.docker/cli-plugins/` as described in https://docs.docker.com/compose/install/linux/#install-the-plugin-manually.
+
+#### Docker instructions
+
+1. [Install Docker](https://docs.docker.com/engine/install/) if you haven't already
+2. Add your user to the `docker` group (`sudo usermod -aG docker $(whoami)`)
+3. Confirm it works by running `docker run --rm docker.io/hello-world` from the Zed built-in terminal
+
+#### Podman instructions
+
+1. [Install Podman](https://podman.io/docs/installation) if you haven't already
+2. Enable/start the Podman socket with `systemctl --user enable --now podman.socket`
+3. Confirm it works by running `podman -r run --rm quay.io/podman/hello` from the Zed built-in terminal
+4. If your host Podman is older than 5.6.0, you also need to set:
+
+```shell
+flatpak override --user dev.zed.Zed --filesystem=/tmp/devcontainer-zed:create
+```
+
+5. Set `"use_podman": true` in your Zed `settings.json`
+
+> [!IMPORTANT]
+> On SELinux-enabled systems you may need to configure the following to avoid Dev Container build failures:
+>
+> ```toml
+> # ~/.config/containers/containers.conf
+> [containers]
+> label = false
+> ```
+>
+> See https://github.com/zed-industries/zed/issues/53697 for details.
+
+See also the [Podman Rootless Tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration) for more detailed instructions and troubleshooting.
+
+#### Podman Desktop instructions
+
+1. [Install Podman Desktop](https://podman-desktop.io/docs/installation/linux-install) if you haven't already
+2. Leave Podman Desktop running in the background while using Zed
+3. Confirm it works by running `podman -r run --rm quay.io/podman/hello` from the Zed built-in terminal
+4. If your host Podman is older than 5.6.0, you also need to set:
+
+```shell
+flatpak override --user dev.zed.Zed --filesystem=/tmp/devcontainer-zed:create
+```
+
+5. Set `"use_podman": true` in your Zed `settings.json`
+
+See also the [Podman Rootless Tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration) for more detailed instructions and troubleshooting.
 
 ### Execute commands on the host system
 

--- a/app-sh/app-sh
+++ b/app-sh/app-sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MIT
+
+# This is a small wrapper for /bin/sh that ensures the /app/bin is first in the PATH
+# no matter what happens in startup files like .profile. This is needed to ensure Zed
+# uses the Flatpak sandbox implementations of Flatpak-provided binaries, instead of
+# anything the user might have in .local/bin/ or similar.
+#
+# POSIX-compatible sh (e.g. Bash started as /bin/sh) sources $ENV after any /etc/profile
+# or ~/.profile sources. We use this to inject a small script that places /app/bin at
+# the beginning of the PATH before the shell script/commands/REPL begin.
+
+export ENV=/app/share/inject-app-bin.sh
+exec /bin/sh "$@"

--- a/app-sh/inject-app-bin.sh
+++ b/app-sh/inject-app-bin.sh
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+
+case "$PATH" in
+  /app/bin:*|/app/bin/:*) ;;
+  *) export PATH=/app/bin:"$PATH"; ;;
+esac

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -1,8 +1,10 @@
 # dev.zed.Zed.yaml
 app-id: dev.zed.Zed
 runtime: org.freedesktop.Sdk
-runtime-version: '25.08'
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.golang
 command: zed-wrapper
 separate-locales: false
 cleanup:
@@ -21,17 +23,21 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland
-
   # Enable access to Flatpak host commands (Needs linter exception: https://docs.flathub.org/docs/for-app-authors/linter#exceptions)
   - --talk-name=org.freedesktop.Flatpak
-
   # Enable access to Freedesktop Secret Service & related auth services since Zed uses Git heavily
   - --talk-name=org.freedesktop.secrets
   - --socket=ssh-auth
   - --socket=gpg-agent
-
+  # Allow Zed to use SSH_ASKPASS for Git operations that require authentication
   - --env=SSH_ASKPASS=/app/libexec/openssh/gnome-ssh-askpass
+  # Set an environment variable to inform users about updating Zed via Flatpak
   - --env=ZED_UPDATE_EXPLANATION="Please use flatpak to update zed"
+  # Ensure Zed uses Flatpak sandbox binaries first over user binaries
+  - --env=SHELL=/app/bin/app-sh
+  # Enable access to Docker & Podman socket
+  - --filesystem=/run/docker.sock:rw
+  - --filesystem=xdg-run/podman/podman.sock:rw
 
 modules:
   - name: ssh-askpass
@@ -116,6 +122,70 @@ modules:
                   project-id: 15525
                   stable-only: true
                   url-template: https://libbsd.freedesktop.org/releases/libmd-$version.tar.xz
+
+  - name: docker
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/golang/bin
+    build-commands:
+      - |-
+        export GOPATH="$PWD"/go TARGET="$PWD"/out
+        cd go/src/github.com/docker/cli && ./scripts/build/binary
+      - install -Dm755 out/docker -T ${FLATPAK_DEST}/bin/docker.real
+      # Remap Docker arguments to respect the document portal sandbox
+      - install -Dm755 docker-map-doc-paths.py ${FLATPAK_DEST}/bin/docker
+      # Include host-spawn shims for known credential helpers
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-secretservice
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-pass
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-gcr
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-acr-env
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-ecr-login
+    sources:
+      - type: git
+        url: https://github.com/docker/cli.git
+        tag: v29.4.0
+        commit: 9d7ad9ff180b43ae5577d048a7bac1159ce7bacf
+        dest: go/src/github.com/docker/cli
+        x-checker-data:
+          type: git
+          url: https://github.com/docker/cli.git
+          tag-pattern: "^(v\\d+\\.\\d+\\.\\d+)$"
+      - type: file
+        path: docker-map-doc-paths.py
+
+  - name: podman
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/golang/bin
+    build-commands:
+      - make PREFIX=${FLATPAK_DEST} podman-remote
+      - install -Dm755 bin/podman-remote -T ${FLATPAK_DEST}/bin/podman.real
+      # Remap Podman arguments to respect the document portal sandbox
+      - install -Dm755 docker-map-doc-paths.py ${FLATPAK_DEST}/bin/podman
+    sources:
+      - type: git
+        url: https://github.com/containers/podman.git
+        tag: v5.8.1
+        commit: c6077f645788743258a1a749f8005b4fb3cbe533
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/containers/podman/releases/latest
+          tag-query: .tag_name
+          timestamp-query: .published_at
+          version-query: $tag | sub("^v"; "")
+      - type: file
+        path: docker-map-doc-paths.py
+
+  - name: app-sh
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 app-sh -t ${FLATPAK_DEST}/bin/
+      - install -Dm644 inject-app-bin.sh -t ${FLATPAK_DEST}/share/
+    sources:
+      - type: file
+        path: app-sh/app-sh
+      - type: file
+        path: app-sh/inject-app-bin.sh
 
   - name: zed
     buildsystem: simple

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -3,6 +3,8 @@ app-id: dev.zed.Zed
 runtime: org.freedesktop.Sdk
 runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.golang
 command: zed-wrapper
 separate-locales: false
 cleanup:
@@ -21,17 +23,21 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland
-
   # Enable access to Flatpak host commands (Needs linter exception: https://docs.flathub.org/docs/for-app-authors/linter#exceptions)
   - --talk-name=org.freedesktop.Flatpak
-
   # Enable access to Freedesktop Secret Service & related auth services since Zed uses Git heavily
   - --talk-name=org.freedesktop.secrets
   - --socket=ssh-auth
   - --socket=gpg-agent
-
+  # Allow Zed to use SSH_ASKPASS for Git operations that require authentication
   - --env=SSH_ASKPASS=/app/libexec/openssh/gnome-ssh-askpass
+  # Set an environment variable to inform users about updating Zed via Flatpak
   - --env=ZED_UPDATE_EXPLANATION="Please use flatpak to update zed"
+  # Ensure Zed uses Flatpak sandbox binaries first over user binaries
+  - --env=SHELL=/app/bin/app-sh
+  # Enable access to Docker & Podman socket
+  - --filesystem=/run/docker.sock:rw
+  - --filesystem=xdg-run/podman/podman.sock:rw
 build-options:
   # Work around Zed's broken sandbox escape #1 - /app/lib must not contain any libraries
   libdir: /app/libflatpak
@@ -121,6 +127,70 @@ modules:
                   project-id: 15525
                   stable-only: true
                   url-template: https://libbsd.freedesktop.org/releases/libmd-$version.tar.xz
+
+  - name: docker
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/golang/bin
+    build-commands:
+      - |-
+        export GOPATH="$PWD"/go TARGET="$PWD"/out
+        cd go/src/github.com/docker/cli && ./scripts/build/binary
+      - install -Dm755 out/docker -T ${FLATPAK_DEST}/bin/docker.real
+      # Remap Docker arguments to respect the document portal sandbox
+      - install -Dm755 docker-map-doc-paths.py ${FLATPAK_DEST}/bin/docker
+      # Include host-spawn shims for known credential helpers
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-secretservice
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-pass
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-gcr
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-acr-env
+      - ln -s /app/bin/host-spawn ${FLATPAK_DEST}/bin/docker-credential-ecr-login
+    sources:
+      - type: git
+        url: https://github.com/docker/cli.git
+        tag: v29.7.2
+        commit: a7dcaa6fdb6ed04aacbfdc76357fdae01605609e
+        dest: go/src/github.com/docker/cli
+        x-checker-data:
+          type: git
+          url: https://github.com/docker/cli.git
+          tag-pattern: ^(v\d+\.\d+\.\d+)$
+      - type: file
+        path: docker-map-doc-paths.py
+
+  - name: podman
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/golang/bin
+    build-commands:
+      - make PREFIX=${FLATPAK_DEST} podman-remote
+      - install -Dm755 bin/podman-remote -T ${FLATPAK_DEST}/bin/podman.real
+      # Remap Podman arguments to respect the document portal sandbox
+      - install -Dm755 docker-map-doc-paths.py ${FLATPAK_DEST}/bin/podman
+    sources:
+      - type: git
+        url: https://github.com/containers/podman.git
+        tag: v6.1.0
+        commit: cade97a52ebdf9dbf9e81de8009015776837a074
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/containers/podman/releases/latest
+          tag-query: .tag_name
+          timestamp-query: .published_at
+          version-query: $tag | sub("^v"; "")
+      - type: file
+        path: docker-map-doc-paths.py
+
+  - name: app-sh
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 app-sh -t ${FLATPAK_DEST}/bin/
+      - install -Dm644 inject-app-bin.sh -t ${FLATPAK_DEST}/share/
+    sources:
+      - type: file
+        path: app-sh/app-sh
+      - type: file
+        path: app-sh/inject-app-bin.sh
 
   - name: zed
     buildsystem: simple

--- a/docker-map-doc-paths.py
+++ b/docker-map-doc-paths.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+
+# SPDX-License-Identifier: MIT
+
+"""
+This is a wrapper script for the Docker/Podman CLIs to make them understand document portal paths.
+
+Inside the Flatpak sandbox, most access to the host system comes through the document portal, a
+special FUSE filesystem that reflects the files/directories that the user has chosen to expose
+to an application. For Zed, this grant happens when you open a new local project and select a
+directory in the standard file chooser, the returned path is in the doc portal filesystem.
+
+The problem for Docker/Podman is that doc portal paths only exist inside the sandbox, not on the
+host system where Docker/Podman is running. So if Zed tries to start a Dev Container and mount
+the source workspace inside the container, Docker/Podman will not recognize the path and reject
+the entire request.
+
+This wrapper steps in and surgically replaces some references to the document portal filesystem
+with their corresponding path(s) on the host system, specifically the source(s) of `--mount`
+options. Note that labels like `devcontainer.local_folder` are unchanged and will still
+reference the doc portal path, which happens to be shared across all Flatpaks (but not the host).
+"""
+
+import functools
+import json
+import os
+import re
+import subprocess
+import sys
+import typing
+from pathlib import Path, PurePath
+
+# Standard location where the document portal is mounted inside the sandbox
+SANDBOX_DOC_PORTAL_PATH = Path("/run/flatpak/doc/")
+
+
+@functools.cache
+def host_path_for(path: Path) -> PurePath:
+    "Get the corresponding host path for a doc portal path"
+    try:
+        return PurePath(
+            subprocess.run(
+                [
+                    "getfattr",
+                    "--name=user.document-portal.host-path",
+                    "--only-values",
+                    "--",
+                    path,
+                ],
+                check=True,
+                capture_output=True,
+            ).stdout.decode("utf-8")
+        )
+    except (subprocess.CalledProcessError, UnicodeDecodeError):
+        return path
+
+
+def doc_portal_paths() -> typing.Generator[Path]:
+    "Iterate over all the known paths provided by the doc portal"
+    for id_dir in SANDBOX_DOC_PORTAL_PATH.iterdir():
+        for file in id_dir.iterdir():
+            yield file
+
+
+def re_literal(values) -> str:
+    "Return a regex that matches any of the given literal values"
+    return "(?:" + "|".join(re.escape(str(val)) for val in values) + ")"
+
+
+def repl_host_path(match: re.Match) -> str:
+    "Replace an re.Match first group with the corresponding host path"
+    return (
+        match.string[match.start() : match.start(1)]
+        + str(host_path_for(match.group(1)))
+        + match.string[match.end(1) : match.end()]
+    )
+
+
+def main(exe: str, argv: list[str]) -> None:
+    # Replace --mount references to a doc path with its host path
+    argv = [
+        re.sub(
+            rf"(?:source|src)=({re_literal(doc_portal_paths())})", repl_host_path, arg
+        )
+        for arg in argv
+    ]
+
+    if argv[1] == "inspect":
+        # As special case, we need to manipulate the output too
+        # This should be unnecessary after https://github.com/zed-industries/zed/pull/53829 is merged
+        proc = subprocess.run(argv, executable=exe, stdout=subprocess.PIPE)
+        output = proc.stdout
+        for doc_path in doc_portal_paths():
+            doc_path_json = json.dumps(str(doc_path)).encode("utf-8")
+            host_path_json = json.dumps(str(host_path_for(doc_path))).encode("utf-8")
+            output = re.sub(
+                rb'"Source":\s*' + re.escape(doc_path_json),
+                b'"Source":' + host_path_json,
+                output,
+            )
+        sys.stdout.buffer.write(output)
+        sys.stdout.buffer.flush()
+        sys.exit(proc.returncode)
+
+    # Exec to the final command line
+    os.execvp(exe, argv)
+
+
+if __name__ == "__main__":
+    main(sys.argv[0] + ".real", sys.argv)

--- a/docker-map-doc-paths.py
+++ b/docker-map-doc-paths.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+
+# SPDX-License-Identifier: MIT
+
+"""
+This is a wrapper script for the Docker/Podman CLIs to make them understand document portal paths.
+
+Inside the Flatpak sandbox, most access to the host system comes through the document portal, a
+special FUSE filesystem that reflects the files/directories that the user has chosen to expose
+to an application. For Zed, this grant happens when you open a new local project and select a
+directory in the standard file chooser, the returned path is in the doc portal filesystem.
+
+The problem for Docker/Podman is that doc portal paths only exist inside the sandbox, not on the
+host system where Docker/Podman is running. So if Zed tries to start a Dev Container and mount
+the source workspace inside the container, Docker/Podman will not recognize the path and reject
+the entire request.
+
+This wrapper steps in and surgically replaces some references to the document portal filesystem
+with their corresponding path(s) on the host system, specifically the source(s) of `--mount`
+options. Note that labels like `devcontainer.local_folder` are unchanged and will still
+reference the doc portal path, which happens to be shared across all Flatpaks (but not the host).
+"""
+
+import functools
+import json
+import os
+import re
+import subprocess
+import sys
+import typing
+from pathlib import Path, PurePath
+
+# Standard location where the document portal is mounted inside the sandbox
+SANDBOX_DOC_PORTAL_PATH = Path("/run/flatpak/doc/")
+
+
+@functools.cache
+def host_path_for(path: Path) -> PurePath:
+    "Get the corresponding host path for a doc portal path"
+    try:
+        return PurePath(
+            subprocess.run(
+                [
+                    "getfattr",
+                    "--name=user.document-portal.host-path",
+                    "--only-values",
+                    "--",
+                    path,
+                ],
+                check=True,
+                capture_output=True,
+            ).stdout.decode("utf-8")
+        )
+    except (subprocess.CalledProcessError, UnicodeDecodeError):
+        return path
+
+
+def doc_portal_paths() -> typing.Generator[Path]:
+    "Iterate over all the known paths provided by the doc portal"
+    for id_dir in SANDBOX_DOC_PORTAL_PATH.iterdir():
+        for file in id_dir.iterdir():
+            yield file
+
+
+def re_literal(values) -> str:
+    "Return a regex that matches any of the given literal values"
+    return "(?:" + "|".join(re.escape(str(val)) for val in values) + ")"
+
+
+def repl_host_path(match: re.Match) -> str:
+    "Replace an re.Match first group with the corresponding host path"
+    return (
+        match.string[match.start() : match.start(1)]
+        + str(host_path_for(match.group(1)))
+        + match.string[match.end(1) : match.end()]
+    )
+
+
+def main(exe: str, argv: list[str]) -> None:
+    argv = [
+        re.sub(
+            rf"(?:source|src)=({re_literal(doc_portal_paths())})", repl_host_path, arg
+        )
+        for arg in argv
+    ]
+    os.execvp(exe, argv)
+
+
+if __name__ == "__main__":
+    main(sys.argv[0] + ".real", sys.argv)


### PR DESCRIPTION
Fixes #336. This is #340 but also installs the `docker` and `podman` CLIs, which avoids the "docker CLI not found" errors that otherwise appear when Zed attempts to start a Devcontainer.

This works for me on Bluefin DX, based on Fedora 43. @Pioneer-1-1 @tomaswarynyca @acch can you give this a try?