### PR TITLE
Revert "feat: don't escape flatpak sandbox (#275)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ To cope with it, Zed's flatpak defaults can be changed to:
 
 ### Environment variables
 
-- `ZED_FLATPAK_NO_ESCAPE`: disable flatpak sandbox escape (default: set)
+- `ZED_FLATPAK_NO_ESCAPE`: disable flatpak sandbox escape (default: not set)
   ```shell
-    $ flatpak override --user --unset-env=ZED_FLATPAK_NO_ESCAPE dev.zed.Zed
+    $ flatpak override --user dev.zed.Zed --env=ZED_FLATPAK_NO_ESCAPE=1
   ```
 
 ### Execute commands on the host system

--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -32,8 +32,6 @@ finish-args:
 
   - --env=SSH_ASKPASS=/app/libexec/openssh/gnome-ssh-askpass
   - --env=ZED_UPDATE_EXPLANATION="Please use flatpak to update zed"
-  # Prevent Zed from escaping the sandbox by default
-  - --env=ZED_FLATPAK_NO_ESCAPE=1
 
 modules:
   - name: ssh-askpass


### PR DESCRIPTION
This reverts commit 786c1dbd13679a33093381fb0002bfe8ebc9f1bf, introduced in https://github.com/flathub/dev.zed.Zed/pull/275

While the intention of the original commit is correct, it unfortunately breaks the default user experience on linux using flatpak.

The reasonable expectation is that installing zed from the flatpak store will result in a functional zed (terminal works, rust and other language tools are available and work), but defaulting to using the sandbox breaks this expectation, resulting in the perception that "zed doesn't work".

Of note, IDEs are specifically called out in the flatpak manual as an example of applications that should *not* be sandboxed: https://docs.flathub.org/docs/for-app-authors/requirements#:~:text=Certain,Flatpak,-%2E

Personally I think the trade-off here should be to have zed distributed via flatpak (it's useful!), but return to the not-sandbox behavior in order to keep functionality intact. 

Hence, this humble submission.