### PR TITLE
workaround: Remove bundled libraries from the leaked LD_LIBRARY_PATH

### DIFF
--- a/dev.zed.Zed.yaml
+++ b/dev.zed.Zed.yaml
@@ -7,9 +7,9 @@ command: zed-wrapper
 separate-locales: false
 cleanup:
   - /include
-  - /lib/*.a
-  - /lib/*.la
-  - /lib/pkgconfig
+  - /libflatpak/*.a
+  - /libflatpak/*.la
+  - /libflatpak/pkgconfig
   - /man
   - /share/info
   - /share/man
@@ -32,6 +32,11 @@ finish-args:
 
   - --env=SSH_ASKPASS=/app/libexec/openssh/gnome-ssh-askpass
   - --env=ZED_UPDATE_EXPLANATION="Please use flatpak to update zed"
+build-options:
+  # Work around Zed's broken sandbox escape #1 - /app/lib must not contain any libraries
+  libdir: /app/libflatpak
+  prepend-pkg-config-path: /app/libflatpak/pkgconfig
+  ldflags: -L/app/libflatpak
 
 modules:
   - name: ssh-askpass
@@ -52,7 +57,7 @@ modules:
   - name: gcr
     buildsystem: meson
     cleanup:
-      - /lib/girepository-1.0
+      - /libflatpak/girepository-1.0
       - /share/gir-1.0
       - /share/doc
       - /share/gtk-doc
@@ -121,11 +126,13 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm 755 bin/* --target-directory ${FLATPAK_DEST}/bin
-      - install -Dm 755 lib/* --target-directory ${FLATPAK_DEST}/lib
+      # Work around Zed's broken sandbox escape #2a: Move Zed's bundled library into a private folder
+      - install -Dm 755 lib/* --target-directory ${FLATPAK_DEST}/libzed
       - install -Dm 755 libexec/* --target-directory ${FLATPAK_DEST}/libexec
       - install -Dm 644 share/applications/* --target-directory ${FLATPAK_DEST}/share/applications
       - install -Dm 644 ${FLATPAK_ID}.metainfo.xml --target-directory ${FLATPAK_DEST}/share/metainfo
       - install -Dm 644 share/icons/hicolor/512x512/apps/zed.png --target-directory ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps
+      - install -Dm 644 ld.so.conf --target-directory ${FLATPAK_DEST}/etc/
 
       # Rename instances of `zed` to `${FLATPAK_ID}`
       - rename zed ${FLATPAK_ID} ${FLATPAK_DEST}/share/icons/hicolor/*/apps/*
@@ -159,6 +166,9 @@ modules:
           is-main-source: true
       - type: file
         path: dev.zed.Zed.metainfo.xml
+      - type: file
+        path: ld.so.conf
+        sha256: 03b7163a4118f64926c75b1d863957eeb8cfabab96a720ad72ce50ab96e1c14b
 
   - name: host-spawn
     buildsystem: simple
@@ -208,3 +218,23 @@ modules:
         path: README.md
       - type: file
         path: sdk_update.md
+  - name: patch-zed
+    buildsystem: simple
+    ensure-writable:
+      - /libexec/zed-editor
+    sources:
+      - type: archive
+        url: https://github.com/NixOS/patchelf/releases/download/0.19.0/patchelf-0.19.0-x86_64.tar.gz
+        only-arches:
+          - x86_64
+        strip-components: 0
+        sha256: a493df96abeecee55d539071e9bace94d32458a3baf54d9495da94f44c647d86
+      - type: archive
+        url: https://github.com/NixOS/patchelf/releases/download/0.19.0/patchelf-0.19.0-aarch64.tar.gz
+        only-arches:
+          - aarch64
+        strip-components: 0
+        sha256: ef0868f7f6e932c1ba974850ab68e893b3206b581442e734258dea66cbc0ebea
+    build-commands:
+      # Work around Zed's broken sandbox escape #2b: Patch RPATH to the private folder
+      - ./bin/patchelf --force-rpath --set-rpath "\$ORIGIN/../libzed:/usr/lib/x86_64-linux-gnu" ${FLATPAK_DEST}/libexec/zed-editor

--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,0 +1,1 @@
+/app/libflatpak


### PR DESCRIPTION
Zed's Flatpak sandbox escape leaks the bundled libraries by setting LD_LIBRARY_PATH. That's Flatpak specific. Because the libraries from LD_LIBRARY_PATH take precedence over but are incompatible with the host's libraries, host tools fail when started from Zed.

A similar issue exists inside the sandbox: /app/lib takes precedences over the runtime libraries & therefore the incompatible Zed libraries lead to issues.

Work around the issues by moving the libraries:
- Patch zed-editor's RPATH & move Zed's bundled libraries into /app/libzed in order to limit their scope to zed-editor
- Move any Flatpak bundled libraries into /app/libflatpak to avoid leaking them into the host
- /app/lib must be kept empty until the issue is fixed upstream

Closes #330